### PR TITLE
Fix SyntaxError occuring on Safari browser

### DIFF
--- a/lib/dark-theme-dashboard.hbs
+++ b/lib/dark-theme-dashboard.hbs
@@ -862,7 +862,7 @@ window.onload = function () {
         elem.style.display = 'none';
       })
 
-      let allMenus = document.querySelectorAll('[id*=iteration-');
+      let allMenus = document.querySelectorAll('[id*=iteration-]');
       allMenus.forEach(function(elem){
         elem.style.borderBottom = 'none';
       })

--- a/lib/dashboard-template.hbs
+++ b/lib/dashboard-template.hbs
@@ -823,7 +823,7 @@ window.onload = function () {
         elem.style.display = 'none';
       })
 
-      let allMenus = document.querySelectorAll('[id*=iteration-');
+      let allMenus = document.querySelectorAll('[id*=iteration-]');
       allMenus.forEach(function(elem){
         elem.style.borderBottom = 'none';
       })

--- a/lib/only-failures-dark-dashboard.hbs
+++ b/lib/only-failures-dark-dashboard.hbs
@@ -832,7 +832,7 @@ window.onload = function () {
         elem.style.display = 'none';
       })
 
-      let allMenus = document.querySelectorAll('[id*=iteration-');
+      let allMenus = document.querySelectorAll('[id*=iteration-]');
       allMenus.forEach(function(elem){
         elem.style.borderBottom = 'none';
       })

--- a/lib/only-failures-dashboard.hbs
+++ b/lib/only-failures-dashboard.hbs
@@ -793,7 +793,7 @@ window.onload = function () {
         elem.style.display = 'none';
       })
 
-      let allMenus = document.querySelectorAll('[id*=iteration-');
+      let allMenus = document.querySelectorAll('[id*=iteration-]');
       allMenus.forEach(function(elem){
         elem.style.borderBottom = 'none';
       })


### PR DESCRIPTION
Hello,

First of all, thank you for creating such an awesome template !
I was trying to use it, but it didn't seem to work.

<img width="1323" alt="Screenshot 2019-06-28 at 16 34 21" src="https://user-images.githubusercontent.com/6889963/60349893-b885ea80-99c2-11e9-85ea-09c5c652b66a.png">

After some digging, i found that there was an error which makes the report unreadable on Safari.
When trying to fetch iterations, safari throws a SyntaxError.

<img width="976" alt="Screenshot 2019-06-28 at 16 43 15" src="https://user-images.githubusercontent.com/6889963/60350472-e3247300-99c3-11e9-849d-e0bb2660a122.png">

I made a Quick fix and i hope if it is okay with you, to merge it and make a new release on npm.

Thank you.