### PR TITLE
Add options to skip headers and sensitive data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 -----------------------------------------------------------------------
 
+## [1.8.9] - 2019-09-24
+
+### Added
+
+- Added an option to hide certain headers from requests and responses by name (Credit to @bassie1995)
+- Added an option to skip outputting headers and bodies in all requests and responses (Credit to @bassie1995)
+
+-----------------------------------------------------------------------
+
 ## [1.8.8] - 2019-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ newman.run({
 });
 ```
 
-Add the `logs` property to the `htmlextra` object, to pass in your own custom title to the report.
+Add the `logs` property to the `htmlextra` object, to add console log statement output in the report.
 
 ```javascript
 const newman = require('newman');
@@ -205,6 +205,48 @@ newman.run({
         htmlextra: {
             export: './<html file path>', // If not specified, the file will be written to `newman/` in the current working directory.
             logs: true // optional, tells the reporter to display the console log statements in the report. This is False by default.
+        }
+    }
+}, function (err) {
+    if (err) { throw err; }
+    console.log('collection run complete!');
+});
+```
+
+Add the `skipHeaders` property to the `htmlextra` object, to pass in an array of header names. It will then not output those headers and their values to the report, for both requests and responses.
+
+```javascript
+const newman = require('newman');
+
+newman.run({
+    collection: require('./examples/Restful_Booker_Collection.json'), // can also provide a URL or path to a local JSON file.
+    environment: require('./examples/Restful_Booker_Environment.json'),
+    reporters: 'htmlextra',
+    reporter: {
+        htmlextra: {
+            export: './<html file path>', // If not specified, the file will be written to `newman/` in the current working directory.
+            skipHeaders: [ 'Server', 'Authorization', 'X-Powered-By' ] // optional, tells the reporter to not output these headers and their values in the report. This is False by default.
+        }
+    }
+}, function (err) {
+    if (err) { throw err; }
+    console.log('collection run complete!');
+});
+```
+
+Add the `skipSensitiveData` property to the `htmlextra` object, to exclude headers and bodies in all requests and responses.
+
+```javascript
+const newman = require('newman');
+
+newman.run({
+    collection: require('./examples/Restful_Booker_Collection.json'), // can also provide a URL or path to a local JSON file.
+    environment: require('./examples/Restful_Booker_Environment.json'),
+    reporters: 'htmlextra',
+    reporter: {
+        htmlextra: {
+            export: './<html file path>', // If not specified, the file will be written to `newman/` in the current working directory.
+            skipSensitiveData: true // optional, tells the not to output headers and bodies for each request and response in the report. This is False by default.
         }
     }
 }, function (err) {

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ A [Newman](https://github.com/postmanlabs/newman) HTML reporter that has been ex
 - A `helper` to give more control over the main `title` shown on the report. Use the `--reporter-htmlextra-title` flag to add your own unique headline.
 - The default filename, if you do not supply the `export` location, is now includes the collection name in the filename rather that the reporter name.
 - Use the `onlyShowFails` option to reduce the report down to just showing the requests that had test failures.
+- The `skipHeaders` option lets you optionally specify an array of header names that should be skipped in the report.
+- Setting the `skipSensitiveData` will skip outputting the headers and bodies for all requests and responses.
 - More to come...
 
 ## Interactive Report Examples

--- a/lib/dark-theme-dashboard.hbs
+++ b/lib/dark-theme-dashboard.hbs
@@ -525,6 +525,7 @@ body, html {
                     </div>
                 </div>
                 {{#with request}}
+                {{#unless @root.skipSensitiveData}}
                 <div class="row">
                     <div class="col-sm-12 mb-3">
                         <div class="card-deck">
@@ -537,10 +538,12 @@ body, html {
                                     <thead class="text-white text-center"><tr><th>Header Name</th><th>Header Value</th></tr></thead>
                                         <tbody>
                                             {{#each headers.members}}
+                                            {{#isNotIn key @root.skipHeaders}}
                                             <tr>
                                                 <td class="text-nowrap">{{key}}</td>
                                                 <td>{{value}}</td>
                                             </tr>
+                                            {{/isNotIn}}
                                             {{/each}}
                                         </tbody>
                                     </table>
@@ -551,6 +554,8 @@ body, html {
                         </div>
                     </div>
                 </div>
+                {{/unless}}
+                {{#unless @root.skipSensitiveData}}
                 {{#if body.raw}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">
@@ -608,7 +613,9 @@ body, html {
                         </div>
                     </div>
                 {{/if}}
+                {{/unless}}
                 {{/with}}
+                {{#unless @root.skipSensitiveData}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">
                     <div class="card-deck">
@@ -621,10 +628,12 @@ body, html {
                                 <thead class="text-white text-center"><tr><th>Header Name</th><th>Header Value</th></tr></thead>
                                     <tbody>
                                         {{#each response.header}}
+                                        {{#isNotIn key @root.skipHeaders}}
                                         <tr>
                                             <td class="text-nowrap">{{key}}</td>
                                             <td>{{value}}</td>
                                         </tr>
+                                        {{/isNotIn}}
                                         {{/each}}
                                     </tbody>
                                 </table>
@@ -635,6 +644,8 @@ body, html {
                     </div>
                 </div>
                 </div>
+                {{/unless}}
+                {{#unless @root.skipSensitiveData}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">
                     <div class="card-deck">
@@ -656,6 +667,7 @@ body, html {
                     </div>
                     </div>
                 </div>
+                {{/unless}}
                 <div class="row">
                     <div class="card border-info">
                         <div class="card-body">

--- a/lib/dashboard-template.hbs
+++ b/lib/dashboard-template.hbs
@@ -498,10 +498,12 @@ body, html {
                                     <thead class="thead-light text-center"><tr><th>Header Name</th><th>Header Value</th></tr></thead>
                                         <tbody>
                                             {{#each headers.members}}
+                                            {{#isNotIn key @root.skipHeaders}}
                                             <tr>
                                                 <td class="text-nowrap">{{key}}</td>
                                                 <td>{{value}}</td>
                                             </tr>
+                                            {{/isNotIn}}
                                             {{/each}}
                                         </tbody>
                                     </table>

--- a/lib/dashboard-template.hbs
+++ b/lib/dashboard-template.hbs
@@ -485,6 +485,7 @@ body, html {
                     </div>
                 </div>
                 {{#with request}}
+                {{#unless @root.skipSensitiveData}}
                 <div class="row">
                     <div class="col-sm-12 mb-3">
                         <div class="card-deck">
@@ -511,7 +512,9 @@ body, html {
                         </div>
                     </div>
                 </div>
+                {{/unless}}
                 {{#if body.raw}}
+                {{#unless @root.skipSensitiveData}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">
                     <div class="card-deck">
@@ -568,7 +571,9 @@ body, html {
                         </div>
                     </div>
                 {{/if}}
+                {{/unless}}
                 {{/with}}
+                {{#unless @root.skipSensitiveData}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">
                     <div class="card-deck">
@@ -581,10 +586,12 @@ body, html {
                                 <thead class="thead-light text-center"><tr><th>Header Name</th><th>Header Value</th></tr></thead>
                                     <tbody>
                                         {{#each response.header}}
+                                        {{#isNotIn key @root.skipHeaders}}
                                         <tr>
                                             <td class="text-nowrap">{{key}}</td>
                                             <td>{{value}}</td>
                                         </tr>
+                                        {{/isNotIn}}
                                         {{/each}}
                                     </tbody>
                                 </table>
@@ -595,6 +602,8 @@ body, html {
                     </div>
                 </div>
                 </div>
+                {{/unless}}
+                {{#unless @root.skipSensitiveData}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">
                     <div class="card-deck">
@@ -616,6 +625,7 @@ body, html {
                     </div>
                     </div>
                 </div>
+                {{/unless}}
                 <div class="row">
                     <div class="card border-info">
                         <div class="card-body">

--- a/lib/dashboard-template.hbs
+++ b/lib/dashboard-template.hbs
@@ -513,8 +513,8 @@ body, html {
                     </div>
                 </div>
                 {{/unless}}
-                {{#if body.raw}}
                 {{#unless @root.skipSensitiveData}}
+                {{#if body.raw}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">
                     <div class="card-deck">

--- a/lib/index.js
+++ b/lib/index.js
@@ -139,6 +139,12 @@ PostmanHTMLExtraReporter = function (newman, options, collectionRunOptions) {
             return options.fn(this);
         }
     });
+    handlebars.registerHelper('isNotIn', function(elem, list, options) {
+        if(list.indexOf(elem) === -1) {
+            return options.fn(this);
+        }
+        return options.inverse(this);
+    });
 
     // @todo throw error here or simply don't catch them and it will show up as warning on newman
     if (options.darkTheme && !options.template && !options.showOnlyFails) {
@@ -319,6 +325,8 @@ PostmanHTMLExtraReporter = function (newman, options, collectionRunOptions) {
             default: `${this.summary.collection.name}.html`,
             path: options.export,
             content: compiler({
+                skipHeaders: options.skipHeaders || [],
+                skipSensitiveData: options.skipSensitiveData || false,
                 timestamp: Date(),
                 version: collectionRunOptions.newmanVersion,
                 aggregations: aggregations,

--- a/lib/index.js
+++ b/lib/index.js
@@ -139,11 +139,12 @@ PostmanHTMLExtraReporter = function (newman, options, collectionRunOptions) {
             return options.fn(this);
         }
     });
-    handlebars.registerHelper('isNotIn', function(elem, list, options) {
-        if(list.indexOf(elem) === -1) {
-            return options.fn(this);
+    handlebars.registerHelper('isNotIn', function (elem, list, options) {
+        if (_.includes(list, elem)) {
+            return options.inverse(this);
         }
-        return options.inverse(this);
+        
+        return options.fn(this);
     });
 
     // @todo throw error here or simply don't catch them and it will show up as warning on newman

--- a/lib/index.js
+++ b/lib/index.js
@@ -143,7 +143,7 @@ PostmanHTMLExtraReporter = function (newman, options, collectionRunOptions) {
         if (_.includes(list, elem)) {
             return options.inverse(this);
         }
-        
+
         return options.fn(this);
     });
 

--- a/lib/only-failures-dark-dashboard.hbs
+++ b/lib/only-failures-dark-dashboard.hbs
@@ -515,6 +515,7 @@ body, html {
                     </div>
                 </div>
                 {{#with request}}
+                {{#unless @root.skipSensitiveData}}
                 <div class="row">
                     <div class="col-sm-12 mb-3">
                         <div class="card-deck">
@@ -527,10 +528,12 @@ body, html {
                                     <thead class="text-white text-center"><tr><th>Header Name</th><th>Header Value</th></tr></thead>
                                         <tbody>
                                             {{#each headers.members}}
+                                            {{#isNotIn key @root.skipHeaders}}
                                             <tr>
                                                 <td class="text-nowrap">{{key}}</td>
                                                 <td>{{value}}</td>
                                             </tr>
+                                            {{/isNotIn}}
                                             {{/each}}
                                         </tbody>
                                     </table>
@@ -541,6 +544,8 @@ body, html {
                         </div>
                     </div>
                 </div>
+                {{/unless}}
+                {{#unless @root.skipSensitiveData}}
                 {{#if body.formdata.members}}
                     <div class="row">
                         <div class="col-sm-12 mb-3">
@@ -598,7 +603,9 @@ body, html {
                         </div>
                     </div>
                 {{/if}}
+                {{/unless}}
                 {{/with}}
+                {{#unless @root.skipSensitiveData}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">
                     <div class="card-deck">
@@ -611,10 +618,12 @@ body, html {
                                 <thead class="text-white text-center"><tr><th>Header Name</th><th>Header Value</th></tr></thead>
                                     <tbody>
                                         {{#each response.header}}
+                                        {{#isNotIn key @root.skipHeaders}}
                                         <tr>
                                             <td class="text-nowrap">{{key}}</td>
                                             <td>{{value}}</td>
                                         </tr>
+                                        {{/isNotIn}}
                                         {{/each}}
                                     </tbody>
                                 </table>
@@ -625,6 +634,8 @@ body, html {
                     </div>
                 </div>
                 </div>
+                {{/unless}}
+                {{#unless @root.skipSensitiveData}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">
                     <div class="card-deck">
@@ -646,6 +657,7 @@ body, html {
                     </div>
                     </div>
                 </div>
+                {{/unless}}
                 <div class="row">
                     <div class="card border-info">
                         <div class="card-body">

--- a/lib/only-failures-dashboard.hbs
+++ b/lib/only-failures-dashboard.hbs
@@ -464,6 +464,7 @@ body, html {
                     </div>
                 </div>
                 {{#with request}}
+                {{#unless @root.skipSensitiveData}}
                 <div class="row">
                     <div class="col-sm-12 mb-3">
                         <div class="card-deck">
@@ -476,10 +477,12 @@ body, html {
                                     <thead class="thead-light text-center"><tr><th>Header Name</th><th>Header Value</th></tr></thead>
                                         <tbody>
                                             {{#each headers.members}}
+                                            {{#isNotIn key @root.skipHeaders}}
                                             <tr>
                                                 <td class="text-nowrap">{{key}}</td>
                                                 <td>{{value}}</td>
                                             </tr>
+                                            {{/isNotIn}}
                                             {{/each}}
                                         </tbody>
                                     </table>
@@ -490,6 +493,8 @@ body, html {
                         </div>
                     </div>
                 </div>
+                {{/unless}}
+                {{#unless @root.skipSensitiveData}}
                 {{#if body.formdata.members}}
                     <div class="row">
                         <div class="col-sm-12 mb-3">
@@ -508,7 +513,7 @@ body, html {
                             </div>
                         </div>
                     </div>
-                {{/if}} 
+                {{/if}}
                 {{#if body.raw}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">
@@ -547,7 +552,9 @@ body, html {
                         </div>
                     </div>
                 {{/if}}
+                {{/unless}}
                 {{/with}}
+                {{#unless @root.skipSensitiveData}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">
                     <div class="card-deck">
@@ -560,10 +567,12 @@ body, html {
                                 <thead class="thead-light text-center"><tr><th>Header Name</th><th>Header Value</th></tr></thead>
                                     <tbody>
                                         {{#each response.header}}
+                                        {{#isNotIn key @root.skipHeaders}}
                                         <tr>
                                             <td class="text-nowrap">{{key}}</td>
                                             <td>{{value}}</td>
                                         </tr>
+                                        {{/isNotIn}}
                                         {{/each}}
                                     </tbody>
                                 </table>
@@ -574,6 +583,8 @@ body, html {
                     </div>
                 </div>
                 </div>
+                {{/unless}}
+                {{#unless @root.skipSensitiveData}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">
                     <div class="card-deck">
@@ -595,6 +606,7 @@ body, html {
                     </div>
                     </div>
                 </div>
+                {{/unless}}
                 <div class="row">
                     <div class="card border-info">
                         <div class="card-body">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman-reporter-htmlextra",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "A newman reporter with added handlebars helpers and separated request iterations",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
You can now skip headers by name, and specify a boolean to hide all request and response headers and bodies. Not adding either keeps the default behavior of showing everything.

Forgot to make a nice branch name but you'll get the point.
Again sorry it took so long, but I think this might be a decent solution without too much complexity.

You make the changelog or should I add an entry?