### PR TITLE
docs(README): Save as devDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm install -g newman-reporter-htmlextra
 For `local` install:
 
 ```console
-npm install -S newman-reporter-htmlextra
+npm install -D newman-reporter-htmlextra
 ```
 
 ## Usage


### PR DESCRIPTION
`newman` and hence `newman-reporter-htmlextra` are most probably being used for testing during development. Encourage saving these as `devDependencies` to reduce (probably) unnecessary runtime deps.