### PR TITLE
Add unclosed div tags

### DIFF
--- a/lib/dark-theme-dashboard.hbs
+++ b/lib/dark-theme-dashboard.hbs
@@ -180,6 +180,8 @@ body, html {
             </li>
             {{/if}}
             </ul>
+        </div>
+        </div>
         {{/with}}
         <div class="tab-content" id="pills-tabContent">
             <div class="tab-pane fade show active" id="pills-summary" role="tabcard" aria-labelledby="pills-summary-tab">

--- a/lib/dark-theme-dashboard.hbs
+++ b/lib/dark-theme-dashboard.hbs
@@ -180,8 +180,6 @@ body, html {
             </li>
             {{/if}}
             </ul>
-        </div>
-        </div>
         {{/with}}
         <div class="tab-content" id="pills-tabContent">
             <div class="tab-pane fade show active" id="pills-summary" role="tabcard" aria-labelledby="pills-summary-tab">
@@ -458,6 +456,8 @@ body, html {
         {{/if}}
 {{/each}}
         </div>
+    </div>
+    </div>
     </div>
     </div>
     </div>

--- a/lib/dashboard-template.hbs
+++ b/lib/dashboard-template.hbs
@@ -138,8 +138,6 @@ body, html {
             </li>
             {{/if}}
             </ul>
-        </div>
-        </div>
         {{/with}}
         <div class="tab-content" id="pills-tabContent">
             <div class="tab-pane fade show active" id="pills-summary" role="tabcard" aria-labelledby="pills-summary-tab">
@@ -418,6 +416,8 @@ body, html {
         {{/if}}
 {{/each}}
         </div>
+    </div>
+    </div>
     </div>
     </div>
     </div>

--- a/lib/dashboard-template.hbs
+++ b/lib/dashboard-template.hbs
@@ -138,6 +138,8 @@ body, html {
             </li>
             {{/if}}
             </ul>
+        </div>
+        </div>
         {{/with}}
         <div class="tab-content" id="pills-tabContent">
             <div class="tab-pane fade show active" id="pills-summary" role="tabcard" aria-labelledby="pills-summary-tab">

--- a/lib/only-failures-dark-dashboard.hbs
+++ b/lib/only-failures-dark-dashboard.hbs
@@ -175,8 +175,6 @@ body, html {
             </li>
             {{/if}}
             </ul>
-        </div>
-        </div>
         {{/with}}
         <div class="tab-content" id="pills-tabContent">
             <div class="tab-pane fade show active" id="pills-summary" role="tabcard" aria-labelledby="pills-summary-tab"> 
@@ -447,6 +445,8 @@ body, html {
         {{/if}}
 {{/each}} 
         </div>      
+    </div>
+    </div>
     </div>
     </div>
     </div>

--- a/lib/only-failures-dark-dashboard.hbs
+++ b/lib/only-failures-dark-dashboard.hbs
@@ -175,6 +175,8 @@ body, html {
             </li>
             {{/if}}
             </ul>
+        </div>
+        </div>
         {{/with}}
         <div class="tab-content" id="pills-tabContent">
             <div class="tab-pane fade show active" id="pills-summary" role="tabcard" aria-labelledby="pills-summary-tab"> 

--- a/lib/only-failures-dashboard.hbs
+++ b/lib/only-failures-dashboard.hbs
@@ -129,8 +129,6 @@ body, html {
             </li>
             {{/if}}
             </ul>
-        </div>
-        </div>
         {{/with}}
         <div class="tab-content" id="pills-tabContent">
             <div class="tab-pane fade show active" id="pills-summary" role="tabcard" aria-labelledby="pills-summary-tab"> 
@@ -396,6 +394,8 @@ body, html {
         {{/if}}
 {{/each}} 
         </div>      
+    </div>
+    </div>
     </div>
     </div>
     </div>

--- a/lib/only-failures-dashboard.hbs
+++ b/lib/only-failures-dashboard.hbs
@@ -129,6 +129,8 @@ body, html {
             </li>
             {{/if}}
             </ul>
+        </div>
+        </div>
         {{/with}}
         <div class="tab-content" id="pills-tabContent">
             <div class="tab-pane fade show active" id="pills-summary" role="tabcard" aria-labelledby="pills-summary-tab"> 


### PR DESCRIPTION
We had issues embedding the reports in an HTML page, because some `div` tags are unclosed.

I think these are the ones we need to add, please verify :)