### PR TITLE
Single folder collections will now show all the folders in multiple iteration runs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -323,7 +323,7 @@ PostmanHTMLExtraReporter = function (newman, options, collectionRunOptions) {
 
                 aggregatedExecutions[execution.cursor.ref] = true;
 
-                if (previous && parent.id === previous.parent.id) {
+                if (previous && parent.id === previous.parent.id && previous.parent.iteration === iteration) {
                     previous.executions.push(current);
                 }
                 else {


### PR DESCRIPTION
Fix for the bug #177 , previous logic was checking only for parent ID . So in case of single parent , the parent.id remains the same across all the iteration and hence the aggregation was being added to same element.