### PR TITLE
Fix for [Bug] no such file or directory, open '/path/to/.html' #141 caused due to invalid filename characters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -341,9 +341,17 @@ PostmanHTMLExtraReporter = function (newman, options, collectionRunOptions) {
 
         _.forEach(this.summary.run.executions, aggregator);
 
+        //  File name validation regex from owasp https://owasp.org/www-community/OWASP_Validation_Regex_Repository
+        var pattern = new RegExp('^(([a-zA-Z]:|\\\\)\\\\)?(((\\.)|' +
+        '(\\.\\.)|([^\\\\/:*?"|<>. ](([^\\\\/:*?"|<>. ])|' +
+        '([^\\\\/:*?"|<>]*[^\\\\/:*?"|<>. ]))?))' +
+        '\\\\)*[^\\\\/:*?"|<>. ](([^\\\\/:*?"|<>. ])' +
+        '|([^\\\\/:*?"|<>]*[^\\\\/:*?"|<>. ]))?$');
+
         this.exports.push({
             name: 'html-reporter-htmlextra',
-            default: this.summary.collection.name ? `${this.summary.collection.name}.html` : 'newman_htmlextra.html',
+            default: (this.summary.collection.name).match(pattern) ?
+                `${this.summary.collection.name}.html` : 'newman_htmlextra.html',
             path: options.export,
             content: compiler({
                 skipHeaders: options.skipHeaders || [],


### PR DESCRIPTION
#141  Added validation to check whether the collection name is a valid file name , else use the default file name newman-html-extra.

Used  below rgex:

^(([a-zA-Z]:|\\)\\)?(((\.)|(\.\.)|([^\\/:*?"|<>. ](([^\\/:*?"|<>. ])|([^\\/:*?"|<>]*[^\\/:*?"|<>. ]))?))\\)*[^\\/:*?"|<>. ](([^\\/:*?"|<>. ])|([^\\/:*?"|<>]*[^\\/:*?"|<>. ]))?$

Available from OWASP:

https://owasp.org/www-community/OWASP_Validation_Regex_Repository