### PR TITLE
 integration tests for PR #204 "Fix for [Bug] no such file or directory, open '/path/to/.html' #141 caused due to invalid filename characters"

### DIFF
--- a/test/integration/cli.test.js
+++ b/test/integration/cli.test.js
@@ -1,9 +1,19 @@
 /* eslint-disable consistent-return */
-const fs = require('fs');
+const fs = require('fs'),
+    _ = require('lodash'),
+
+    //  File name validation regex from owasp https://owasp.org/www-community/OWASP_Validation_Regex_Repository
+    pattern = new RegExp('^(([a-zA-Z]:|\\\\)\\\\)?(((\\.)|' +
+     '(\\.\\.)|([^\\\\/:*?"|<>. ](([^\\\\/:*?"|<>. ])|' +
+     '([^\\\\/:*?"|<>]*[^\\\\/:*?"|<>. ]))?))' +
+     '\\\\)*[^\\\\/:*?"|<>. ](([^\\\\/:*?"|<>. ])' +
+     '|([^\\\\/:*?"|<>]*[^\\\\/:*?"|<>. ]))?$');
 
 describe('Newman and htmlextra run from the CLI', function () {
     const outFile = 'out/newman-report.html',
-        newman = 'node ./.temp/node_modules/newman/bin/newman.js';
+        newman = 'node ./.temp/node_modules/newman/bin/newman.js',
+        invalidCollectionNameFolder = 'test/requests/collection_with_name_containing_invalid_characters';
+    let files = fs.readdirSync(invalidCollectionNameFolder);
 
     beforeEach(function (done) {
         fs.stat('out', function (err) {
@@ -16,12 +26,132 @@ describe('Newman and htmlextra run from the CLI', function () {
     });
 
     afterEach(function (done) {
+        let files = fs.readdirSync('newman');
+
+        // delete newman folder content
+        files.forEach(function (file) {
+            fs.unlinkSync('newman/' + file);
+        });
+
         fs.stat(outFile, function (err) {
             if (err) {
                 return done();
             }
 
             fs.unlink(outFile, done);
+        });
+    });
+
+    // Get all collection files from the invalidCollectionNameFolder
+    files = files.filter(function (file) {
+        return (/^((?!(package(-lock)?))|.+)\.json/).test(file);
+    });
+
+    // For each collection run newman and validate output
+    files.forEach(function (file) {
+        // Get collection file as JSON and get collection name as obj.info.name
+        let obj = JSON.parse(fs.readFileSync(invalidCollectionNameFolder + '/' + file, 'utf8'));
+
+        it('should correctly generate the dark theme html report for collection' +
+        'name (' + obj.info.name + ')', function (done) {
+            let collection = invalidCollectionNameFolder + '/' + file;
+
+            exec(`${newman} run ${collection} -r htmlextra  --reporter-htmlextra-darkTheme`,
+                function (code) {
+                    expect(code, 'should have exit code of 0').to.equal(0);
+
+                    // output will be stored to newman folder , read the output files
+                    let outputFile = fs.readdirSync('newman'),
+                        name = obj.info.name;
+
+                    /* If the file is for invalid character then ,
+                    validate the html file name to be newman_htmlextra-{timestamp}.html*/
+                    if ((obj.info.name).match(pattern) === null) {
+                        name = 'newman_htmlextra';
+                        if (outputFile.length !== 0) {
+                            name = (outputFile[0])
+                                .match(new RegExp('^(' + _.escapeRegExp(name) +
+                                ')-\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{3}-\\d.html$'));
+                            name === null ? expect
+                                .fail('File name was ' + outputFile[0]) : expect(outputFile[0]).to.equal(name[0]);
+                        }
+                        else if (outputFile.length === 0) {
+                            expect.fail('No output files were created');
+                        }
+                    }
+                    else {
+                        /* If the file is for invalid character then validate the html file name to be,
+                        collectionname-{timestamp}.html.
+                        if collection name is in format test\\test2 then consider only test2*/
+
+                        name = (name).includes('\\') ? (name).split('\\').slice(-1)[0] : name;
+                        if (outputFile.length !== 0) {
+                            name = (outputFile[0])
+                                .match(new RegExp('^(' + _.escapeRegExp(name) +
+                                ')-\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{3}-\\d.html$'));
+                            name === null ? expect
+                                .fail('File name was ' + outputFile[0]) : expect(outputFile[0]).to.equal(name[0]);
+                        }
+                        else if (outputFile.length === 0) {
+                            expect.fail('No output files were created');
+                        }
+                    }
+                    done();
+                });
+        });
+    });
+
+    // For each collection run newman and validate output
+    files.forEach(function (file) {
+        // Get collection file as JSON and get collection name as obj.info.name
+        let obj = JSON.parse(fs.readFileSync(invalidCollectionNameFolder + '/' + file, 'utf8'));
+
+        it('should correctly generate the html report for collection' +
+        'name (' + obj.info.name + ')', function (done) {
+            let collection = invalidCollectionNameFolder + '/' + file;
+
+            exec(`${newman} run ${collection} -r htmlextra`,
+                function (code) {
+                    expect(code, 'should have exit code of 0').to.equal(0);
+
+                    // output will be stored to newman folder , read the output files
+                    let outputFile = fs.readdirSync('newman'),
+                        name = obj.info.name;
+
+                    /* If the file is for invalid character then ,
+                    validate the html file name to be newman_htmlextra-{timestamp}.html*/
+                    if ((obj.info.name).match(pattern) === null) {
+                        name = 'newman_htmlextra';
+                        if (outputFile.length !== 0) {
+                            name = (outputFile[0])
+                                .match(new RegExp('^(' + _.escapeRegExp(name) +
+                                ')-\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{3}-\\d.html$'));
+                            name === null ? expect
+                                .fail('File name was ' + outputFile[0]) : expect(outputFile[0]).to.equal(name[0]);
+                        }
+                        else if (outputFile.length === 0) {
+                            expect.fail('No output files were created');
+                        }
+                    }
+                    else {
+                        /* If the file is for invalid character then validate the html file name to be,
+                        collectionname-{timestamp}.html.
+                        if collection name is in format test\\test2 then consider only test2*/
+
+                        name = (name).includes('\\') ? (name).split('\\').slice(-1)[0] : name;
+                        if (outputFile.length !== 0) {
+                            name = (outputFile[0])
+                                .match(new RegExp('^(' + _.escapeRegExp(name) +
+                                ')-\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{3}-\\d.html$'));
+                            name === null ? expect
+                                .fail('File name was ' + outputFile[0]) : expect(outputFile[0]).to.equal(name[0]);
+                        }
+                        else if (outputFile.length === 0) {
+                            expect.fail('No output files were created');
+                        }
+                    }
+                    done();
+                });
         });
     });
 

--- a/test/integration/library.test.js
+++ b/test/integration/library.test.js
@@ -1,8 +1,17 @@
 /* eslint-disable no-console */
-var fs = require('fs');
+var fs = require('fs'),
+    _ = require('lodash'),
+    //  File name validation regex from owasp https://owasp.org/www-community/OWASP_Validation_Regex_Repository
+    pattern = new RegExp('^(([a-zA-Z]:|\\\\)\\\\)?(((\\.)|' +
+        '(\\.\\.)|([^\\\\/:*?"|<>. ](([^\\\\/:*?"|<>. ])|' +
+        '([^\\\\/:*?"|<>]*[^\\\\/:*?"|<>. ]))?))' +
+        '\\\\)*[^\\\\/:*?"|<>. ](([^\\\\/:*?"|<>. ])' +
+        '|([^\\\\/:*?"|<>]*[^\\\\/:*?"|<>. ]))?$');
 
 describe('Newman and htmlextra run from a script', function () {
-    var outFile = 'out/newman-report.htmlextra.html';
+    var outFile = 'out/newman-report.htmlextra.html',
+        invalidCollectionNameFolder = 'test/requests/collection_with_name_containing_invalid_characters',
+        files = fs.readdirSync(invalidCollectionNameFolder);
 
     beforeEach(function (done) {
         // eslint-disable-next-line consistent-return
@@ -16,6 +25,13 @@ describe('Newman and htmlextra run from a script', function () {
     });
 
     afterEach(function (done) {
+        let files = fs.readdirSync('newman');
+
+        // delete newman folder content
+        files.forEach(function (file) {
+            fs.unlinkSync('newman/' + file);
+        });
+
         // eslint-disable-next-line consistent-return
         fs.stat(outFile, function (err) {
             if (err) {
@@ -23,6 +39,128 @@ describe('Newman and htmlextra run from a script', function () {
             }
 
             fs.unlink(outFile, done);
+        });
+    });
+
+    // Get all collection files from the invalidCollectionNameFolder
+    files = files.filter(function (file) {
+        return (/^((?!(package(-lock)?))|.+)\.json/).test(file);
+    });
+
+    // For each collection send newman.run and validate output
+    files.forEach(function (file) {
+        // Get collection file as JSON and get collection name as obj.info.name
+        let obj = JSON.parse(fs.readFileSync(invalidCollectionNameFolder + '/' + file, 'utf8'));
+
+        it('should correctly generate the dark theme html report for collection' +
+        'name (' + obj.info.name + ')', function (done) {
+            newman.run({
+                collection: invalidCollectionNameFolder + '/' + file,
+                reporters: ['htmlextra'],
+                reporter: { htmlextra: { darkTheme: true } }
+            // eslint-disable-next-line consistent-return
+            }, function (err, summary) {
+                if (err) { return done(err); }
+                expect(summary.collection.name).to.equal(obj.info.name);
+                expect(summary.run.stats.iterations.total).to.equal(1);
+
+                // output will be stored to newman folder , read the output files
+                let outputFile = fs.readdirSync('newman'),
+                    name = obj.info.name;
+
+                /* If the file is for invalid character then ,
+                validate the html file name to be newman_htmlextra-{timestamp}.html*/
+                if ((obj.info.name).match(pattern) === null) {
+                    name = 'newman_htmlextra';
+                    if (outputFile.length !== 0) {
+                        name = (outputFile[0])
+                            .match(new RegExp('^(' + _.escapeRegExp(name) +
+                            ')-\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{3}-\\d.html$'));
+                        name === null ? expect
+                            .fail('File name was ' + outputFile[0]) : expect(outputFile[0]).to.equal(name[0]);
+                    }
+                    else if (outputFile.length === 0) {
+                        expect.fail('No output files were created');
+                    }
+                }
+                else {
+                    /* If the file is for invalid character then validate the html file name to be,
+                    collectionname-{timestamp}.html.
+                    if collection name is in format test\\test2 then consider only test2*/
+
+                    name = (name).includes('\\') ? (name).split('\\').slice(-1)[0] : name;
+                    if (outputFile.length !== 0) {
+                        name = (outputFile[0])
+                            .match(new RegExp('^(' + _.escapeRegExp(name) +
+                            ')-\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{3}-\\d.html$'));
+                        name === null ? expect
+                            .fail('File name was ' + outputFile[0]) : expect(outputFile[0]).to.equal(name[0]);
+                    }
+                    else if (outputFile.length === 0) {
+                        expect.fail('No output files were created');
+                    }
+                }
+                done();
+            });
+        });
+    });
+
+
+    // For each collection send newman.run and validate output
+    files.forEach(function (file) {
+        // Get collection file as JSON and get collection name as obj.info.name
+        let obj = JSON.parse(fs.readFileSync(invalidCollectionNameFolder + '/' + file, 'utf8'));
+
+        it('should correctly generate the html report for collection' +
+        'name (' + obj.info.name + ')', function (done) {
+            newman.run({
+                collection: invalidCollectionNameFolder + '/' + file,
+                reporters: ['htmlextra'],
+                reporter: { htmlextra: { } }
+            // eslint-disable-next-line consistent-return
+            }, function (err, summary) {
+                if (err) { return done(err); }
+                expect(summary.collection.name).to.equal(obj.info.name);
+                expect(summary.run.stats.iterations.total).to.equal(1);
+
+                // output will be stored to newman folder , read the output files
+                let outputFile = fs.readdirSync('newman'),
+                    name = obj.info.name;
+
+                /* If the file is for invalid character then ,
+                validate the html file name to be newman_htmlextra-{timestamp}.html*/
+                if ((obj.info.name).match(pattern) === null) {
+                    name = 'newman_htmlextra';
+                    if (outputFile.length !== 0) {
+                        name = (outputFile[0])
+                            .match(new RegExp('^(' + _.escapeRegExp(name) +
+                            ')-\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{3}-\\d.html$'));
+                        name === null ? expect
+                            .fail('File name was ' + outputFile[0]) : expect(outputFile[0]).to.equal(name[0]);
+                    }
+                    else if (outputFile.length === 0) {
+                        expect.fail('No output files were created');
+                    }
+                }
+                else {
+                    /* If the file is for invalid character then validate the html file name to be,
+                    collectionname-{timestamp}.html.
+                    if collection name is in format test\\test2 then consider only test2*/
+
+                    name = (name).includes('\\') ? (name).split('\\').slice(-1)[0] : name;
+                    if (outputFile.length !== 0) {
+                        name = (outputFile[0])
+                            .match(new RegExp('^(' + _.escapeRegExp(name) +
+                            ')-\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{3}-\\d.html$'));
+                        name === null ? expect
+                            .fail('File name was ' + outputFile[0]) : expect(outputFile[0]).to.equal(name[0]);
+                    }
+                    else if (outputFile.length === 0) {
+                        expect.fail('No output files were created');
+                    }
+                }
+                done();
+            });
         });
     });
 

--- a/test/requests/collection_with_name_containing_invalid_characters/README.md
+++ b/test/requests/collection_with_name_containing_invalid_characters/README.md
@@ -1,0 +1,35 @@
++-----------------------------------+-----------------+
+| File Name                         | Collection Name |
++-----------------------------------+-----------------+
+| invalid1.postman_collection.json  | C:\             |
++-----------------------------------+-----------------+
+| invalid2.postman_collection.json  | test|test       |
++-----------------------------------+-----------------+
+| invalid3.postman_collection.json  | test?test       |
++-----------------------------------+-----------------+
+| invalid4.postman_collection.json  | test<test       |
++-----------------------------------+-----------------+
+| invalid5.postman_collection.json  | test>test       |
++-----------------------------------+-----------------+
+| invalid6.postman_collection.json  | test"test       |
++-----------------------------------+-----------------+
+| invalid8.postman_collection.json  | test/test       |
++-----------------------------------+-----------------+
+| invalid9.postman_collection.json  | test:test       |
++-----------------------------------+-----------------+
+| invalid10.postman_collection.json | test*test       |
++-----------------------------------+-----------------+
+| valid1.postman_collection.json    | TEST TEST       |
++-----------------------------------+-----------------+
+| valid2.postman_collection.json    | TEST &TEST      |
++-----------------------------------+-----------------+
+| valid3.postman_collection.json    | TEST_TEST       |
++-----------------------------------+-----------------+
+| valid4.postman_collection.json    | test\test       |
++-----------------------------------+-----------------+
+| valid5.postman_collection.json    | test.test       |
++-----------------------------------+-----------------+
+| valid6.postman_collection.json    | test test test  |
++-----------------------------------+-----------------+
+| valid7.postman_collection.json    | test^test test  |
++-----------------------------------+-----------------+

--- a/test/requests/collection_with_name_containing_invalid_characters/README.md
+++ b/test/requests/collection_with_name_containing_invalid_characters/README.md
@@ -1,35 +1,20 @@
-+-----------------------------------+-----------------+
+
 | File Name                         | Collection Name |
-+-----------------------------------+-----------------+
+|--|--|
 | invalid1.postman_collection.json  | C:\             |
-+-----------------------------------+-----------------+
 | invalid2.postman_collection.json  | test|test       |
-+-----------------------------------+-----------------+
 | invalid3.postman_collection.json  | test?test       |
-+-----------------------------------+-----------------+
 | invalid4.postman_collection.json  | test<test       |
-+-----------------------------------+-----------------+
 | invalid5.postman_collection.json  | test>test       |
-+-----------------------------------+-----------------+
 | invalid6.postman_collection.json  | test"test       |
-+-----------------------------------+-----------------+
 | invalid8.postman_collection.json  | test/test       |
-+-----------------------------------+-----------------+
 | invalid9.postman_collection.json  | test:test       |
-+-----------------------------------+-----------------+
 | invalid10.postman_collection.json | test*test       |
-+-----------------------------------+-----------------+
 | valid1.postman_collection.json    | TEST TEST       |
-+-----------------------------------+-----------------+
 | valid2.postman_collection.json    | TEST &TEST      |
-+-----------------------------------+-----------------+
 | valid3.postman_collection.json    | TEST_TEST       |
-+-----------------------------------+-----------------+
 | valid4.postman_collection.json    | test\test       |
-+-----------------------------------+-----------------+
 | valid5.postman_collection.json    | test.test       |
-+-----------------------------------+-----------------+
 | valid6.postman_collection.json    | test test test  |
-+-----------------------------------+-----------------+
 | valid7.postman_collection.json    | test^test test  |
-+-----------------------------------+-----------------+
+

--- a/test/requests/collection_with_name_containing_invalid_characters/invalid1.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/invalid1.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "C:\\",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/invalid10.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/invalid10.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "test*test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/invalid2.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/invalid2.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "test|test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/invalid3.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/invalid3.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "test?test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/invalid4.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/invalid4.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "test<test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/invalid5.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/invalid5.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "test>test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/invalid6.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/invalid6.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "521e8868-6228-425e-88c6-974b4f7d9f84",
+		"name": "test\"test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "06f3048d-24b8-4fcd-a9ed-8bc7cf330f71",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "d60a87c0-c9c4-45d1-ab44-514ce30882dd",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "71983446-754b-4677-9ef7-95be243899a2",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "f8a2cecd-1953-4edf-8bb2-02ffc305fa33",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/invalid8.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/invalid8.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "test/test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/invalid9.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/invalid9.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "test:test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/valid1.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/valid1.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "TEST TEST",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/valid2.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/valid2.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "TEST &TEST",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/valid3.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/valid3.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "TEST_TEST",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/valid4.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/valid4.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "test\\test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/valid5.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/valid5.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "test.test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/valid6.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/valid6.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "test test test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/test/requests/collection_with_name_containing_invalid_characters/valid7.postman_collection.json
+++ b/test/requests/collection_with_name_containing_invalid_characters/valid7.postman_collection.json
@@ -1,0 +1,83 @@
+{
+	"info": {
+		"_postman_id": "4411e122-ee87-4d76-9f8f-d1f29ff807c1",
+		"name": "test^test test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "test|test",
+			"item": [
+				{
+					"name": "GET Simple request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8122a622-c9a0-48a2-89ad-8c3e4da70ca4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "fc9557dc-2d13-4a30-ab9f-c309174098be",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://jsonplaceholder.typicode.com/posts/1",
+							"protocol": "http",
+							"host": [
+								"jsonplaceholder",
+								"typicode",
+								"com"
+							],
+							"path": [
+								"posts",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "3de3ca20-2e75-488f-9d0c-78c3df280568",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "88910f0a-2d43-4390-8d8a-3a262c5e1c6e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}


### PR DESCRIPTION
Added tests to validate HTML file creation for valid and invalid collection names, The code will create newman_htmlextra-(timestamp}.html  if the collection contains invalid filename character, else will create collectionname-{timestamp).html ; in the newman folder.

This test will fail until the PR #204 is merged