### PR TITLE
Changed condition to avoid errors in case of null

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -129,7 +129,7 @@ PostmanHTMLExtraReporter = function (newman, options, collectionRunOptions) {
             list = list.toLowerCase()
         }
 
-        if (elem !== undefined) {
+        if (elem) {
             var convertedElem = elem.toLowerCase()
         }
 


### PR DESCRIPTION
Changed condition from ( elem !== undefined ) to ( elem ) because was causing errors when elem was null.