### PR TITLE
Fix request/response representation when --reporter-htmlextra-noSyntaxHighlighting is used.

### DIFF
--- a/lib/dashboard-template.hbs
+++ b/lib/dashboard-template.hbs
@@ -415,6 +415,14 @@ table.dataTable td, table.dataTable tr {
     vertical-align: middle;
 } 
 
+body.theme-dark code {
+    color: #ccd2d8!important;
+} 
+
+body.theme-light code {
+    color: #000000!important;
+} 
+
 </style>
 </head>
 <body class="">

--- a/lib/only-failures-dashboard.hbs
+++ b/lib/only-failures-dashboard.hbs
@@ -418,6 +418,14 @@ table.dataTable td, table.dataTable tr {
     vertical-align: middle;
 } 
 
+body.theme-dark code {
+    color: #ccd2d8!important;
+} 
+
+body.theme-light code {
+    color: #000000!important;
+} 
+
 </style>
 </head>
 <body>


### PR DESCRIPTION
Fix request/response representation when --reporter-htmlextra-noSyntaxHighlighting is used.

Before fix:
<img width="1019" alt="Screenshot 2021-01-27 at 09 49 40" src="https://user-images.githubusercontent.com/630000/105966755-5bae5280-6085-11eb-93fd-be8d411d7bd4.png">

After fix:
<img width="1022" alt="Screenshot 2021-01-27 at 09 50 20" src="https://user-images.githubusercontent.com/630000/105966782-636df700-6085-11eb-8867-cd1ddd6c2687.png">
