### PR TITLE
[FEAT] Added omitRequestBodies and omitResponseBodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 
 *.log
 *.log.*
+.idea/
 
 /out/
 /newman/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules
 
 *.log
 *.log.*
-.idea/
 
 /out/
 /newman/

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ newman run collection.json -r htmlextra
 | `--reporter-htmlextra-title` | This optional flag can be used to give your report a different main `Title` in the centre of the report. If this is not set, the report will show "Newman Run Dashboard". | `newman run collection.json -r htmlextra --reporter-htmlextra-title "My Newman Report"`|
 | `--reporter-htmlextra-titleSize` | An optional flag to reduce the size of the main report title. The sizes range from `1` to `6`, the higher the number, the smaller the title will be. The default size is `2`. | `newman run collection.json -r htmlextra --reporter-htmlextra-titleSize 4`|
 | `--reporter-htmlextra-logs` | This optional flag shows any console log statements in the collection, on the final report. This is `false` by default. | `newman run collection.json -r htmlextra --reporter-htmlextra-logs`|
+| `--reporter-htmlextra-omitRequestBodies` | An optional flag which allows you to exclude all `Request Bodies` from the final report | `newman run collection.json -r htmlextra --reporter-htmlextra-omitRequestBodies`|
+| `--reporter-htmlextra-omitResponseBodies` | An optional flag which allows you to exclude all `Response Bodies` from the final report | `newman run collection.json -r htmlextra --reporter-htmlextra-omitResponseBodies`|
 | `--reporter-htmlextra-hideRequestBody` | An optional flag which allows you to exclude certain `Request Bodies` from the final report. Enter the name of the request that you wish to hide. | `newman run collection.json -r htmlextra --reporter-htmlextra-hideRequestBody "Login"`|
 | `--reporter-htmlextra-hideResponseBody` | An optional flag which allows you to exclude certain `Response Bodies` from the final report. Enter the name of the request that you wish to hide. | `newman run collection.json -r htmlextra --reporter-htmlextra-hideResponseBody "Auth Request"`|
 | `--reporter-htmlextra-showEnvironmentData` | An optional flag which allows you to show all the `Environment` variables used during the run, in the final report | `newman run collection.json -r htmlextra --reporter-htmlextra-showEnvironmentData`|
@@ -133,6 +135,8 @@ newman.run({
             // titleSize: 4,
             // omitHeaders: true,
             // skipHeaders: "Authorization",
+            // omitRequestBodies: true,
+            // omitResponseBodies: true,
             // hideRequestBody: ["Login"],
             // hideResponseBody: ["Auth Request"],
             // showEnvironmentData: true,

--- a/bin/htmlextra.js
+++ b/bin/htmlextra.js
@@ -16,6 +16,8 @@ program
     .option('--reporter-htmlextra-titleSize', 'Specify the size of the main report title')
     .option('--reporter-htmlextra-omitHeaders', 'Excludes all `Headers` from the final report')
     .option('--reporter-htmlextra-skipHeaders', 'Exclude certain `Headers` from the final report')
+    .option('--reporter-htmlextra-omitRequestBodies', 'Exclude all `Request Bodies` from the final report')
+    .option('--reporter-htmlextra-omitResponseBodies', 'Exclude all `Response Bodies` from the final report')
     .option('--reporter-htmlextra-hideRequestBody', 'Exclude certain `Request Bodies` from the final report')
     .option('--reporter-htmlextra-hideResponseBody', 'Exclude certain `Response Bodies` from the final report')
     .option('--reporter-htmlextra-showEnvironmentData', 'Displays all the `Environment` variables used during the run')

--- a/lib/dashboard-template.hbs
+++ b/lib/dashboard-template.hbs
@@ -935,7 +935,7 @@ body.theme-light code {
                 {{/unless}}
                 {{/with}}
                 {{#unless @root.skipSensitiveData}}
-                {{#unless @root.hideRequestBodies}}
+                {{#unless @root.omitRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.raw}}
@@ -962,7 +962,7 @@ body.theme-light code {
                 {{/unless}}
                 {{/unless}}
                 {{#unless @root.skipSensitiveData}}
-                {{#unless @root.hideRequestBodies}}
+                {{#unless @root.omitRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.formdata.members}}
@@ -989,7 +989,7 @@ body.theme-light code {
                 {{/unless}}
                 {{/unless}}
                 {{#unless @root.skipSensitiveData}}
-                {{#unless @root.hideRequestBodies}}
+                {{#unless @root.omitRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.urlencoded.members}}
@@ -1016,7 +1016,7 @@ body.theme-light code {
                 {{/unless}}
                 {{/unless}}}
                 {{#unless @root.skipSensitiveData}}
-                {{#unless @root.hideRequestBodies}}
+                {{#unless @root.omitRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.graphql}}
@@ -1081,7 +1081,7 @@ body.theme-light code {
                 {{/unless}}
                 {{/unless}}
                 {{#unless @root.skipSensitiveData}}
-                {{#unless @root.hideResponseBodies}}
+                {{#unless @root.omitResponseBodies}}
                 {{#isNotIn item.name @root.hideResponseBody}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">

--- a/lib/dashboard-template.hbs
+++ b/lib/dashboard-template.hbs
@@ -935,6 +935,7 @@ body.theme-light code {
                 {{/unless}}
                 {{/with}}
                 {{#unless @root.skipSensitiveData}}
+                {{#unless @root.hideRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.raw}}
@@ -959,7 +960,9 @@ body.theme-light code {
                 {{/with}}
                 {{/isNotIn}}
                 {{/unless}}
+                {{/unless}}
                 {{#unless @root.skipSensitiveData}}
+                {{#unless @root.hideRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.formdata.members}}
@@ -984,7 +987,9 @@ body.theme-light code {
                 {{/with}}
                 {{/isNotIn}}
                 {{/unless}}
+                {{/unless}}
                 {{#unless @root.skipSensitiveData}}
+                {{#unless @root.hideRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.urlencoded.members}}
@@ -1009,7 +1014,9 @@ body.theme-light code {
                 {{/with}}
                 {{/isNotIn}}
                 {{/unless}}
+                {{/unless}}}
                 {{#unless @root.skipSensitiveData}}
+                {{#unless @root.hideRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.graphql}}
@@ -1039,6 +1046,7 @@ body.theme-light code {
                 {{/if}}
                 {{/with}}
                 {{/isNotIn}}
+                {{/unless}}
                 {{/unless}}
                 {{#unless @root.omitHeaders}}
                 {{#unless @root.skipSensitiveData}}
@@ -1073,6 +1081,7 @@ body.theme-light code {
                 {{/unless}}
                 {{/unless}}
                 {{#unless @root.skipSensitiveData}}
+                {{#unless @root.hideResponseBodies}}
                 {{#isNotIn item.name @root.hideResponseBody}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">
@@ -1096,6 +1105,7 @@ body.theme-light code {
                     </div>
                 </div>
                 {{/isNotIn}}
+                {{/unless}}
                 {{/unless}}
                 {{#if consoleLogs.length}}
                 <div class="row">

--- a/lib/dashboard-template.hbs
+++ b/lib/dashboard-template.hbs
@@ -1014,7 +1014,7 @@ body.theme-light code {
                 {{/with}}
                 {{/isNotIn}}
                 {{/unless}}
-                {{/unless}}}
+                {{/unless}}
                 {{#unless @root.skipSensitiveData}}
                 {{#unless @root.omitRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}

--- a/lib/index.js
+++ b/lib/index.js
@@ -372,6 +372,8 @@ PostmanHTMLExtraReporter = function (newman, options, collectionRunOptions) {
                 skipHeaders: options.skipHeaders || [],
                 skipEnvironmentVars: options.skipEnvironmentVars || [],
                 skipGlobalVars: options.skipGlobalVars || [],
+                omitRequestBodies: options.omitRequestBodies || false,
+                omitResponseBodies: options.omitResponseBodies || false,
                 hideRequestBody: options.hideRequestBody || [],
                 hideResponseBody: options.hideResponseBody || [],
                 showEnvironmentData: options.showEnvironmentData || false,

--- a/lib/only-failures-dashboard.hbs
+++ b/lib/only-failures-dashboard.hbs
@@ -926,6 +926,7 @@ body.theme-light code {
                 {{/unless}}
                 {{/with}}
                 {{#unless @root.skipSensitiveData}}
+                {{#unless @root.hideRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.raw}}
@@ -950,7 +951,9 @@ body.theme-light code {
                 {{/with}}
                 {{/isNotIn}}
                 {{/unless}}
+                {{/unless}}
                 {{#unless @root.skipSensitiveData}}
+                {{#unless @root.hideRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.formdata.members}}
@@ -975,7 +978,9 @@ body.theme-light code {
                 {{/with}}
                 {{/isNotIn}}
                 {{/unless}}
+                {{/unless}}
                 {{#unless @root.skipSensitiveData}}
+                {{#unless @root.hideRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.urlencoded.members}}
@@ -1000,7 +1005,9 @@ body.theme-light code {
                 {{/with}}
                 {{/isNotIn}}
                 {{/unless}}
+                {{/unless}}
                 {{#unless @root.skipSensitiveData}}
+                {{#unless @root.hideRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.graphql}}
@@ -1030,6 +1037,7 @@ body.theme-light code {
                 {{/if}}
                 {{/with}}
                 {{/isNotIn}}
+                {{/unless}}
                 {{/unless}}
                 {{#unless @root.omitHeaders}}
                 {{#unless @root.skipSensitiveData}}
@@ -1064,6 +1072,7 @@ body.theme-light code {
                 {{/unless}}
                 {{/unless}}
                 {{#unless @root.skipSensitiveData}}
+                {{#unless @root.hideResponseBodies}}
                 {{#isNotIn item.name @root.hideResponseBody}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">
@@ -1087,6 +1096,7 @@ body.theme-light code {
                     </div>
                 </div>
                 {{/isNotIn}}
+                {{/unless}}
                 {{/unless}}
                 {{#if consoleLogs.length}}
                 <div class="row">

--- a/lib/only-failures-dashboard.hbs
+++ b/lib/only-failures-dashboard.hbs
@@ -926,7 +926,7 @@ body.theme-light code {
                 {{/unless}}
                 {{/with}}
                 {{#unless @root.skipSensitiveData}}
-                {{#unless @root.hideRequestBodies}}
+                {{#unless @root.omitRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.raw}}
@@ -953,7 +953,7 @@ body.theme-light code {
                 {{/unless}}
                 {{/unless}}
                 {{#unless @root.skipSensitiveData}}
-                {{#unless @root.hideRequestBodies}}
+                {{#unless @root.omitRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.formdata.members}}
@@ -980,7 +980,7 @@ body.theme-light code {
                 {{/unless}}
                 {{/unless}}
                 {{#unless @root.skipSensitiveData}}
-                {{#unless @root.hideRequestBodies}}
+                {{#unless @root.omitRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.urlencoded.members}}
@@ -1007,7 +1007,7 @@ body.theme-light code {
                 {{/unless}}
                 {{/unless}}
                 {{#unless @root.skipSensitiveData}}
-                {{#unless @root.hideRequestBodies}}
+                {{#unless @root.omitRequestBodies}}
                 {{#isNotIn item.name @root.hideRequestBody}}
                 {{#with request}}
                 {{#if body.graphql}}
@@ -1072,7 +1072,7 @@ body.theme-light code {
                 {{/unless}}
                 {{/unless}}
                 {{#unless @root.skipSensitiveData}}
-                {{#unless @root.hideResponseBodies}}
+                {{#unless @root.omitResponseBodies}}
                 {{#isNotIn item.name @root.hideResponseBody}}
                 <div class="row">
                 <div class="col-sm-12 mb-3">

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.20.2",
+      "version": "1.20.3",
       "license": "Apache-2.0",
       "dependencies": {
         "autolinker": "^3.14.2",


### PR DESCRIPTION
I added the new options omitRequestBodies and omitResponseBodies. Since there is an option to omitHeaders separately from skipSensitiveData and for bodies only the name-based options I felt this is a good addition to allow a lot of variety in hiding possible sensitive data, e.g. by only hiding headers and request bodies. 