### PR TITLE
Added a flag to display the progress bar which is off by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 -----------------------------------------------------------------------
+## [1.22.5] - 2022-01-27
+
+### Added
+
+- Turned off the progress bar by default and included an optional `displayProgressBar` flag
+
+-----------------------------------------------------------------------
+
 ## [1.22.4] - 2022-01-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ newman run collection.json -r htmlextra
 | `--reporter-htmlextra-noSyntaxHighlighting` | An optional flag which allows you disable the code syntax highlighting. This _could_ enhance the performance of opening larger reports. | `newman run collection.json -r htmlextra --reporter-htmlextra-noSyntaxHighlighting`|
 | `--reporter-htmlextra-showFolderDescription` | An optional flag which allows you to show all the folder descriptions, in the final report | `newman run collection.json -r htmlextra --reporter-htmlextra-showFolderDescription`|
 | `--reporter-htmlextra-timezone` | An optional flag which allows you to set the timezone on the final report's timestamp | `newman run collection.json -r htmlextra --reporter-htmlextra-timezone "Australia/Sydney"`|
+| `--reporter-htmlextra-displayProgressBar` | An optional flag which displays the progress of the current Newman run in the CLI | `newman run collection.json -r htmlextra --reporter-htmlextra-displayProgressBar`|
 
 ---
 
@@ -150,7 +151,8 @@ newman.run({
             // showFolderDescription: true,
             // timezone: "Australia/Sydney",
             // skipFolders: "folder name with space,folderWithoutSpace",
-            // skipRequests: "request name with space,requestNameWithoutSpace"
+            // skipRequests: "request name with space,requestNameWithoutSpace",
+            // displayProgressBar: true
         }
     }
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -214,35 +214,34 @@ PostmanHTMLExtraReporter = function (newman, options, collectionRunOptions) {
             });
         }
     });
-    // Add progress feedback for the reporter
-    if (_.includes(collectionRunOptions.reporters, 'cli') || _.get(collectionRunOptions.reporter, 'cli') || _.includes(collectionRunOptions.reporters, 'json') || _.get(collectionRunOptions.reporter, 'json') || _.includes(collectionRunOptions.reporters, 'progress') || _.get(collectionRunOptions.reporter, 'progress')) {
-        newman.on('start', function (err, o) {
-            if (err) { return; }
-            console.log(`Using ${chalk.green('htmlextra')} version ${chalk.green(version)}`)
-        });
-    }
-    if (!_.includes(collectionRunOptions.reporters, 'progress') && !_.get(collectionRunOptions.reporter, 'progress') && !_.includes(collectionRunOptions.reporters, 'cli') && !_.get(collectionRunOptions.reporter, 'cli') && !_.includes(collectionRunOptions.reporters, 'json') && !_.get(collectionRunOptions.reporter, 'json')) {
-        var bar = new progress.Bar({
-            format: 'Newman Run Progress |' + chalk.green('{bar}') + '| {percentage}% || Requests: {value}/{total} || ETA: {eta}s',
-            barCompleteChar: '\u2588',
-            barIncompleteChar: '\u2591',
-            hideCursor: true
-        });
+    if (options.displayProgressBar) {
+        // Add progress feedback for the reporter
+        if (_.includes(collectionRunOptions.reporters, 'cli') || _.get(collectionRunOptions.reporter, 'cli') || _.includes(collectionRunOptions.reporters, 'json') || _.get(collectionRunOptions.reporter, 'json') || _.includes(collectionRunOptions.reporters, 'progress') || _.get(collectionRunOptions.reporter, 'progress')) {
+            newman.on('start', function (err, o) {
+                if (err) { return err; }
+            });
+        }
+        if (!_.includes(collectionRunOptions.reporters, 'progress') && !_.get(collectionRunOptions.reporter, 'progress') && !_.includes(collectionRunOptions.reporters, 'cli') && !_.get(collectionRunOptions.reporter, 'cli') && !_.includes(collectionRunOptions.reporters, 'json') && !_.get(collectionRunOptions.reporter, 'json')) {
+            var bar = new progress.Bar({
+                format: 'Newman Run Progress |' + chalk.green('{bar}') + '| {percentage}% || Requests: {value}/{total} || ETA: {eta}s',
+                barCompleteChar: '\u2588',
+                barIncompleteChar: '\u2591',
+                hideCursor: true
+            });
 
-        newman.on('start', function (err, o) {
-            if (err) { return; }
-            console.log(`Using ${chalk.green('htmlextra')} version ${chalk.green(version)}`)
-            bar.start(o.cursor.length * o.cursor.cycles, 0);
-        });
+            newman.on('start', function (err, o) {
+                if (err) { return; }
+                bar.start(o.cursor.length * o.cursor.cycles, 0);
+            });
 
-        newman.on('item', function () {
-            bar.increment();
-        });
+            newman.on('item', function () {
+                bar.increment();
+            });
 
-        newman.on('done', function () {
-            bar.stop();
-            console.log(`Created the ${chalk.green('htmlextra')} report.`);
-        });
+            newman.on('done', function () {
+                bar.stop();
+            });
+        }
     }
 
     newman.on('console', function (err, o) {
@@ -399,6 +398,7 @@ PostmanHTMLExtraReporter = function (newman, options, collectionRunOptions) {
                 showMarkdownLinks: options.showMarkdownLinks || false,
                 noSyntaxHighlighting: options.noSyntaxHighlighting || false,
                 showFolderDescription: options.showFolderDescription || false,
+                displayProgressBar: options.silentProgressBar || false,
                 browserTitle: options.browserTitle || 'Newman Summary Report',
                 title: options.title || 'Newman Run Dashboard',
                 titleSize: options.titleSize || 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "newman-reporter-htmlextra",
-  "version": "1.22.4",
+  "version": "1.22.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newman-reporter-htmlextra",
-  "version": "1.22.4",
+  "version": "1.22.5",
   "description": "A newman reporter with added handlebars helpers and separated request iterations",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
I've made the progress bar off by default and added a flag so that if it's needed, it can be added as an additional argument.

![image](https://user-images.githubusercontent.com/17089546/151357843-25e6fa6f-b4ca-49ac-8881-dc21cd4e40a6.png)

This was done due to the console output being over polluted in certain use cases that run collections in parallel.
