### PR TITLE
Added word-wrap for the "Value" column

### DIFF
--- a/lib/dashboard-template.hbs
+++ b/lib/dashboard-template.hbs
@@ -429,6 +429,13 @@ body.theme-light code {
     color: #000000!important;
 }
 
+.text-wrap {
+    word-wrap: break-word; 
+    min-width: 600px; 
+    max-width: 600px; 
+    white-space: normal;
+}
+
 </style>
 </head>
 <body class="theme-dark">
@@ -941,7 +948,7 @@ body.theme-light code {
                                             {{#isNotIn key @root.skipHeaders}}
                                             <tr>
                                                 <td class="text-nowrap">{{key}}</td>
-                                                <td style="word-wrap: break-word; min-width: 600px; max-width: 600px; white-space: normal; ">{{value}}</td>
+                                                <td class="text-wrap">{{value}}</td>
                                             </tr>
                                             {{/isNotIn}}
                                             {{/each}}
@@ -1088,7 +1095,7 @@ body.theme-light code {
                                         {{#isNotIn key @root.skipHeaders}}
                                         <tr>
                                             <td class="text-nowrap">{{key}}</td>
-                                            <td style="word-wrap: break-word; min-width: 600px; max-width: 600px; white-space: normal; ">{{value}}</td>
+                                            <td class="text-wrap">{{value}}</td>
                                         </tr>
                                         {{/isNotIn}}
                                         {{/each}}

--- a/lib/only-failures-dashboard.hbs
+++ b/lib/only-failures-dashboard.hbs
@@ -432,6 +432,13 @@ body.theme-light code {
     color: #000000!important;
 } 
 
+.text-wrap {
+    word-wrap: break-word; 
+    min-width: 600px; 
+    max-width: 600px; 
+    white-space: normal;
+}
+
 </style>
 </head>
 <body>
@@ -915,7 +922,7 @@ body.theme-light code {
                                             {{#isNotIn key @root.skipHeaders}}
                                             <tr>
                                                 <td class="text-nowrap">{{key}}</td>
-                                                <td style="word-wrap: break-word; min-width: 600px; max-width: 600px; white-space: normal; ">{{value}}</td>
+                                                <td class="text-wrap">{{value}}</td>
                                             </tr>
                                             {{/isNotIn}}
                                             {{/each}}
@@ -1062,7 +1069,7 @@ body.theme-light code {
                                         {{#isNotIn key @root.skipHeaders}}
                                         <tr>
                                             <td class="text-nowrap">{{key}}</td>
-                                            <td style="word-wrap: break-word; min-width: 600px; max-width: 600px; white-space: normal; ">{{value}}</td>
+                                            <td class="text-wrap">{{value}}</td>
                                         </tr>
                                         {{/isNotIn}}
                                         {{/each}}


### PR DESCRIPTION
Added word-wrap for the "Value" column of "Request Headers" and  "Response Headers" tables, so that longer values (such as bearer tokens) don't scroll horizontally off the screen.