### PR TITLE
Update newman to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node": ">=6"
   },
   "peerDependencies": {
-    "newman": "^5.1.2"
+    "newman": "^6.0.0"
   },
   "devDependencies": {
     "async": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-mocha": "^6.3.0",
     "eslint-plugin-security": "^1.4.0",
     "mocha": "^9.2.0",
-    "newman": "^5.2.4",
+    "newman": "^6.0.0",
     "parse-gitignore": "^1.0.1",
     "recursive-readdir": "^2.2.2",
     "shelljs": "^0.8.4"


### PR DESCRIPTION
A proposed change to update to the newman 6.0.0 release as seen in [this issue](https://github.com/DannyDainton/newman-reporter-htmlextra/issues/416). Users have reported that this tool works just fine, I'm opening this PR in the hopes there is automated builds which will validate this, if not it will need some review from SMEs as I'm not familiar with this library