### PR TITLE
Update @budibase/handlebars-helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "README.MD"
   ],
   "dependencies": {
-    "@budibase/handlebars-helpers": "0.11.8",
+    "@budibase/handlebars-helpers": "0.13.1",
     "chalk": "4.1.2",
     "cli-progress": "3.10.0",
     "commander": "6.2.1",


### PR DESCRIPTION
Transitive dependencies on @budibase/handlebars-helpers have a number of problems that can be resolved by updating to the latest version.

I was sorely tempted to introduce SemVer patterns on the deps because even with this update, I know there are outstanding problems with this module which will require another PR here to fix :(